### PR TITLE
feat: youtube動画の埋め込み機能実装完了 #10

### DIFF
--- a/app/views/beats/show.html.erb
+++ b/app/views/beats/show.html.erb
@@ -25,3 +25,8 @@
 
 <%= link_to 'Edit', edit_beat_path(@beat) %> |
 <%= link_to 'Back', beats_path %>
+
+<br>
+
+<iframe id="ytplayer" type="text/html" width="640" height="360"
+  src="https://www.youtube.com/embed/<%= @beat.url %>?autoplay=1&playsinline=1&controls=0"></iframe>


### PR DESCRIPTION
APIを使わず、iframeタグでRailsを使い動的に埋め込み機能を追加
- 埋め込み・コントロールの非表示OK
- ミュートじゃないと自動再生できない。スマホでは自動再生できない。
- なので、動画をタップしてスタートの方向で一旦進める。